### PR TITLE
Make compatible with ASpace v4.x

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[BUG] "
+labels: bug
+assignees: lorawoodford
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+_Optional, but include if helpful/relevant_
+**Desktop:**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone/Mobile:**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[FEATURE]"
+labels: enhancement
+assignees: lorawoodford
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Description
+<!--- Describe your changes.  Why is this required?  What problem does it solve?  What functionality does it extend? -->
+
+## Related GitHub Issue
+<!--- Please link to GitHub Issue here: -->
+
+## Testing
+<!--- Please describe, in detail, how you tested your changes. -->
+
+## Screenshot(s):
+<!--- Optional screenshots of changes if relevant and helpful to reviewers -->
+
+## Checklist
+
+- [ ] ✔️ Have you assigned at least one reviewer?
+- [ ] 🔗 Have you referenced any issues this PR will close?
+- [ ] ⬇️ Have you merged the latest upstream changes into your branch? 
+- [ ] 🧪 Have you added tests to cover these changes?  If not, why:
+
+- [ ] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
+
+- [ ] 📘 Have you updated/added any relevant readmes/comments in the codebase?
+- [ ] 📚 Have you updated/added any external documentation (e.g. Confluence)?

--- a/.github/workflows/codescan.yml
+++ b/.github/workflows/codescan.yml
@@ -1,0 +1,24 @@
+name: Code Scan
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+
+jobs:
+  code_scan:
+    runs-on: ubuntu-latest
+    env:
+      PROD_ARCHIVESSPACE_VERSION: v4.1.0
+
+    steps:
+    - name: Setup ArchivesSpace ${{ env.PROD_ARCHIVESSPACE_VERSION }}
+      uses: Smithsonian/caas-aspace-services/.github/actions/setup_archivesspace@main
+      with:
+        archivesspace-version: ${{ env.PROD_ARCHIVESSPACE_VERSION }}
+        plugin: ${{ github.event.repository.name }}
+
+    - name: Run Rubocop
+      run: |
+        ./build/run rubocop -Ddir="plugins/${{ github.event.repository.name }}"

--- a/.github/workflows/diff.yml
+++ b/.github/workflows/diff.yml
@@ -1,0 +1,17 @@
+name: Diff modified views
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'frontend/views/**'
+  push:
+    paths:
+      - 'frontend/views/**'
+
+jobs:
+  diff:
+    uses: Smithsonian/caas-aspace-services/.github/workflows/diff.yml@main
+    with:
+      prod_archivesspace_version: v4.1.0

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,9 @@
+inherit_from: ../../.rubocop.yml
+
+inherit_mode:
+  merge:
+    - Include
+
+AllCops:
+  Include:
+    - .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # lassb-aspace-overrides
 
-This plugin implements the following overrides for ArchivesSpace 3.3.1:
+This plugin implements the following overrides:
 
 * Redirects the Bulk Import Templates link to SI's ArchivesSpace manual (see `frontend/views/shared/_header_repository.html.erb`)
 * Removes the link for non-admin users to update their own user accounts (see `frontend/views/shared/_header_user.html.erb`)
 * Overrides the MarcXMLAuthAgentBaseMap module to ensure that related agents and subjects are NOT imported via the LCNAF plugin (and other MARC agent imports), since those additional headings resulted in duplicates that lacked authority identifiers (see `backend/plugin_init.rb`)
-

--- a/frontend/views/shared/_header_repository.html.erb
+++ b/frontend/views/shared/_header_repository.html.erb
@@ -157,7 +157,9 @@
                     <% end %>
                     <% if user_can?('create_job') %>
                         <li><%= link_to t("job._plural"), {:controller => :jobs, :action => :index}, :class => "dropdown-item" %></li>
+                        <%# SI Override - Use local import templates %>
                         <li><%= link_to t("bulk_import.templates"), "https://confluence.si.edu/pages/viewpage.action?spaceKey=LAS&title=Import+Templates", :target => "_blank", :class => "dropdown-item"  %></li>
+                        <%# End SI Override %>
                       <li class="dropdown-divider"></li>
                     <% end %>
 

--- a/frontend/views/shared/_header_repository.html.erb
+++ b/frontend/views/shared/_header_repository.html.erb
@@ -1,102 +1,96 @@
-<div class="col-md-12 repository-header">
-<nav class="navbar navbar-default">
-  <div class="container-fluid">
-    <div class="navbar-header">
-      <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target=".nav-repository-collapse" aria-expanded="false">
-        <span class="sr-only"><%= I18n.t("navbar.toggle_navigation") %></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-        <span class="icon-bar"></span>
-      </button>
-    </div>
-    <div class="navbar-collapse nav-repository-collapse collapse navbar-default">
+<div class="repository-header">
+  <nav class="navbar navbar-expand-md navbar-light bg-light">
+    <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarContent" aria-controls="navbarContent" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="navbar-collapse collapse flex-column" id="navbarContent">
       <% if session[:user] and session[:repo_id] %>
-        <ul class="nav navbar-nav">
-          <li <% if controller_name === "welcome" %>class="active"<% end %>>
-            <%= link_to raw('<span class="glyphicon glyphicon-home"></span><span class="sr-only">' + I18n.t("breadcrumb.home") + '</span>'), :controller => :welcome, :action => :index %>
+        <ul class="nav navbar-nav w-100 px-3 border-bottom">
+          <li class="d-flex<%= (controller_name === "welcome" ? ' bg-bsCoolGray' : '') %>">
+            <%= link_to raw('<span class="glyphicon glyphicon-home"></span><span class="sr-only">' + t("breadcrumb.home") + '</span>'), { :controller => :welcome, :action => :index }, class: 'p-3' %>
           </li>
-          <li class="dropdown browse-container">
-            <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= I18n.t("actions.browse") %> <b class="caret"></b></a>
+          <li class="d-flex align-self-stretch align-items-center dropdown browse-container">
+            <button class="btn h-100 d-flex align-items-center gap-x-1 rounded-0 hover-bsCoolGray dropdown-toggle" data-toggle="dropdown"><%= t("actions.browse") %> <b class="caret"></b></button>
             <ul class="dropdown-menu">
-              <li><%= link_to I18n.t("accession._plural"), :controller => :accessions, :action => :index %></li>
-              <li><%= link_to I18n.t("resource._plural"), :controller => :resources, :action => :index %></li>
-              <li><%= link_to I18n.t("digital_object._plural"), :controller => :digital_objects, :action => :index %></li>
-              <li class="divider"></li>
-              <li><%= link_to I18n.t("subject._plural"), :controller => :subjects, :action => :index %></li>
-              <li><%= link_to I18n.t("agent._plural"), :controller => :agents, :action => :index %></li>
-              <li><%= link_to I18n.t("container_profile._plural"), :controller => :container_profiles, :action => :index %></li>
-              <li><%= link_to I18n.t("location._plural"), :controller => :locations, :action => :index %></li>
-              <li><%= link_to I18n.t("event._plural"), :controller => :events, :action => :index %></li>
-              <li><%= link_to I18n.t("collection_management._plural"), :controller => :collection_management, :action => :index %></li>
-              <li><%= link_to I18n.t("classification._plural"), :controller => :classifications, :action => :index %></li>
-              <li><%= link_to I18n.t("assessment._plural"), :controller => :assessments, :action => :index %></li>
-              <li class="divider"></li>
-              <li><%= link_to I18n.t("job._plural"), :controller => :jobs, :action => :index %></li>
+              <li><%= link_to t("accession._plural"), {:controller => :accessions, :action => :index}, :class => "dropdown-item" %></li>
+              <li><%= link_to t("resource._plural"), {:controller => :resources, :action => :index}, :class => "dropdown-item" %></li>
+              <li><%= link_to t("digital_object._plural"), {:controller => :digital_objects, :action => :index}, :class => "dropdown-item" %></li>
+              <li class="dropdown-divider"></li>
+              <li><%= link_to t("subject._plural"), {:controller => :subjects, :action => :index}, :class => "dropdown-item" %></li>
+              <li><%= link_to t("agent._plural"), {:controller => :agents, :action => :index}, :class => "dropdown-item" %></li>
+              <li><%= link_to t("container_profile._plural"), {:controller => :container_profiles, :action => :index}, :class => "dropdown-item" %></li>
+              <li><%= link_to t("location._plural"), {:controller => :locations, :action => :index}, :class => "dropdown-item" %></li>
+              <li><%= link_to t("event._plural"), {:controller => :events, :action => :index}, :class => "dropdown-item" %></li>
+              <li><%= link_to t("collection_management._plural"), {:controller => :collection_management, :action => :index}, :class => "dropdown-item" %></li>
+              <li><%= link_to t("classification._plural"), {:controller => :classifications, :action => :index}, :class => "dropdown-item" %></li>
+              <li><%= link_to t("assessment._plural"), {:controller => :assessments, :action => :index}, :class => "dropdown-item" %></li>
+              <li class="dropdown-divider"></li>
+              <li><%= link_to t("job._plural"), {:controller => :jobs, :action => :index}, :class => "dropdown-item" %></li>
             </ul>
           </li>
           <% if ['update_accession_record', 'update_resource_record', 'update_digital_object_record',
-                 'update_subject_record', 'update_event_record',
-                 'update_agent_record', 'update_location_record', 'update_container_profile', 'create_job'].find {|p| user_can?(p)} %>
-            <li class="dropdown create-container">
-              <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= I18n.t("navbar.create") %> <b class="caret"></b></a>
+                  'update_subject_record', 'update_event_record',
+                  'update_agent_record', 'update_location_record', 'update_container_profile'].find {|p| user_can?(p)} %>
+            <li class="d-flex align-self-stretch align-items-center dropdown create-container">
+              <button class="btn h-100 d-flex align-items-center gap-x-1 rounded-0 hover-bsCoolGray dropdown-toggle" data-toggle="dropdown"><%= t("navbar.create") %></button>
               <ul class="dropdown-menu">
                 <% if ['update_accession_record', 'update_resource_record', 'update_digital_object_record'].find {|p| user_can?(p)} %>
                   <% if user_can?('update_accession_record') %>
-                    <li><%= link_to I18n.t("accession._singular"), :controller => :accessions, :action => :new %></li>
+                    <li><%= link_to t("accession._singular"), {:controller => :accessions, :action => :new}, :class => "dropdown-item" %></li>
                   <% end %>
                   <% if user_can?('update_resource_record') %>
-                    <li><%= link_to I18n.t("resource._singular"), :controller => :resources, :action => :new %></li>
+                    <li><%= link_to t("resource._singular"), {:controller => :resources, :action => :new}, :class => "dropdown-item" %></li>
                   <% end %>
                   <% if user_can?('update_digital_object_record') %>
-                    <li><%= link_to I18n.t("digital_object._singular"), :controller => :digital_objects, :action => :new %></li>
+                    <li><%= link_to t("digital_object._singular"), {:controller => :digital_objects, :action => :new}, :class => "dropdown-item" %></li>
                   <% end %>
 
                   <% if ['update_subject_record', 'update_event_record',
-                         'update_agent_record', 'update_location_record', 'update_container_profile'].find {|p| user_can?(p)} %>
-                    <li class="divider"></li>
+                          'update_agent_record', 'update_location_record', 'update_container_profile'].find {|p| user_can?(p)} %>
+                    <li class="dropdown-divider"></li>
                   <% end %>
                 <% end %>
                 <% if user_can?('update_subject_record') %>
-                  <li><%= link_to I18n.t("subject._singular"), :controller => :subjects, :action => :new %></li>
+                  <li><%= link_to t("subject._singular"), {:controller => :subjects, :action => :new}, :class => "dropdown-item" %></li>
                 <% end %>
                 <% if user_can?('update_agent_record') %>
                   <li class="dropdown-submenu">
-                    <a href="javascript:void(0);"><%= I18n.t("agent._singular") %></a>
+                    <a class="dropdown-item" href="javascript:void(0);"><%= t("agent._singular") %></a>
                     <ul class="dropdown-menu">
-                      <li><%= link_to I18n.t("agent_person._singular"), :controller => :agents, :action => :new, :agent_type => :agent_person %></li>
-                      <li><%= link_to I18n.t("agent_family._singular"), :controller => :agents, :action => :new, :agent_type => :agent_family %></li>
-                      <li><%= link_to I18n.t("agent_corporate_entity._singular"), :controller => :agents, :action => :new, :agent_type => :agent_corporate_entity %></li>
-                      <li><%= link_to I18n.t("agent_software._singular"), :controller => :agents, :action => :new, :agent_type => :agent_software %></li>
+                      <li><%= link_to t("agent_person._singular"), {:controller => :agents, :action => :new, :agent_type => :agent_person}, :class => "dropdown-item" %></li>
+                      <li><%= link_to t("agent_family._singular"), {:controller => :agents, :action => :new, :agent_type => :agent_family}, :class => "dropdown-item" %></li>
+                      <li><%= link_to t("agent_corporate_entity._singular"), {:controller => :agents, :action => :new, :agent_type => :agent_corporate_entity}, :class => "dropdown-item" %></li>
+                      <li><%= link_to t("agent_software._singular"), {:controller => :agents, :action => :new, :agent_type => :agent_software}, :class => "dropdown-item" %></li>
                     </ul>
                   </li>
                 <% end %>
                 <% if user_can?('update_container_profile_record') %>
-                  <li><%= link_to I18n.t("container_profile._singular"), :controller => :container_profiles, :action => :new %></li>
+                  <li><%= link_to t("container_profile._singular"), {:controller => :container_profiles, :action => :new}, :class => "dropdown-item" %></li>
                 <% end %>
                 <% if user_can?('update_location_record') %>
                   <li class="dropdown-submenu">
-                    <a href="javascript:void(0);"><%= I18n.t("location._singular") %></a>
+                    <a class="dropdown-item" href="javascript:void(0);"><%= t("location._singular") %></a>
                     <ul class="dropdown-menu">
-                      <li><%= link_to I18n.t("location._frontend.action.single"), :controller => :locations, :action => :new %></li>
-                      <li><%= link_to I18n.t("location._frontend.action.batch"), :controller => :locations, :action => :batch %></li>
+                      <li><%= link_to t("location._frontend.action.single"), {:controller => :locations, :action => :new}, :class => "dropdown-item" %></li>
+                      <li><%= link_to t("location._frontend.action.batch"), {:controller => :locations, :action => :batch}, :class => "dropdown-item" %></li>
                     </ul>
                   </li>
                 <% end %>
                 <% if user_can?('update_event_record') %>
-                  <li><%= link_to I18n.t("event._singular"), :controller => :events, :action => :new %></li>
+                  <li><%= link_to t("event._singular"), {:controller => :events, :action => :new}, :class => "dropdown-item" %></li>
                 <% end %>
                 <% if user_can?('update_classification_record') %>
-                  <li><%= link_to I18n.t("classification._singular"), :controller => :classifications, :action => :new %></li>
+                  <li><%= link_to t("classification._singular"), {:controller => :classifications, :action => :new}, :class => "dropdown-item" %></li>
                 <% end %>
                 <% if user_can?('update_assessment_record') %>
-                  <li><%= link_to I18n.t("assessment._singular"), :controller => :assessments, :action => :new %></li>
+                  <li><%= link_to t("assessment._singular"), {:controller => :assessments, :action => :new}, :class => "dropdown-item" %></li>
                 <% end %>
 
                 <% if user_can?('create_job') %>
-                  <li class="divider"></li>
+                  <li class="dropdown-divider"></li>
 
                   <li class="dropdown-submenu">
-                    <a href="javascript:void(0);"><%= I18n.t("job._singular") %></a>
+                    <a class="dropdown-item" href="javascript:void(0);"><%= t("job._singular") %></a>
                     <ul class="dropdown-menu">
                       <% job_types.each do |type, perms| %>
                         <% next if type == 'generate_slugs_job' && !AppConfig[:use_human_readable_urls] %>
@@ -104,7 +98,7 @@
                         <%# We only want to trigger bulk imports from within a resource record %>
                         <% next if type == 'bulk_import_job' %>
                         <% if perms['create_permissions'].reject{|perm| user_can?(perm)}.empty? %>
-                          <li><%= link_to I18n.t("job.types.#{type}", :default => type), :controller => :jobs, :action => :new, :job_type => type %></li>
+                          <li><%= link_to t("job.types.#{type}", :default => type), {:controller => :jobs, :action => :new, :job_type => type}, :class => "dropdown-item" %></li>
                         <% end %>
                       <% end %>
                     </ul>
@@ -114,84 +108,81 @@
               </ul>
             </li>
           <% end %>
-          <li>
+          <li class="px-4">
             <%= form_tag(url_for(:controller => :search, :action => :do_search), :method => :get, :class => "navbar-form pull-left") do %>
-              <div class="input-group">
-                <label for="global-search-box" class="sr-only sr-only-focusable"><%= I18n.t("navbar.search_placeholder") %></label>
-                <input id="global-search-box" type="text" class="col-md-2 form-control" placeholder="<%= I18n.t("navbar.search_placeholder") %>" name="q" value="<%= params[:q] %>"/>
-                <div class="input-group-btn">
-                  <button id="global-search-button" class="btn btn-default" title="<%= I18n.t("navbar.search_button_title") %>" aria-label="<%= I18n.t("navbar.search_button_title") %>"><span class="glyphicon glyphicon-search"></span></button>
-                  <button class="btn btn-default search-switcher last" title="<%= I18n.t("navbar.show_advanced_search_button_title") %>" aria-label="<%= I18n.t("navbar.show_advanced_search_button_title") %>" aria-expanded="false" <% if params["advanced"] %>style="display:none"<% end %>><span class='glyphicon glyphicon-chevron-down'></span></button>
+              <div class="input-group bg-white">
+                <label for="global-search-box" class="sr-only sr-only-focusable"><%= t("navbar.search_placeholder") %></label>
+                <input id="global-search-box" type="text" class="form-control rounded-left" placeholder="<%= t("navbar.search_placeholder") %>" name="q" value="<%= params[:q] %>"/>
+                <div class="input-group-append">
+                  <button id="global-search-button" class="btn btn-default" title="<%= t("navbar.search_button_title") %>" aria-label="<%= t("navbar.search_button_title") %>"><span class="glyphicon glyphicon-search"></span></button>
+                  <button class="btn btn-default search-switcher last" title="<%= t("navbar.show_advanced_search_button_title") %>" aria-label="<%= t("navbar.show_advanced_search_button_title") %>" aria-expanded="false" <% if params["advanced"] %>style="display:none"<% end %>><span class='glyphicon glyphicon-chevron-down'></span></button>
                 </div>
               </div>
             <% end %>
           </li>
-          <li>
-            <div class="advanced-search-container" <% if params["advanced"].blank? or params["advanced"]  === 'false' %>style="display: none"<% end %>>
-              <%= render_aspace_partial :partial => "shared/advanced_search" %>
-            </div>
-          </li>
-          <li class="pull-right navbar-nav-right">
-            <ul class="nav navbar-nav">
+          <li class="ml-auto">
+            <ul class="nav navbar-nav gap-x-2">
               <li class="repo-container">
+              <div class="btn-group" role="group">
+                <a href="<%= url_for :controller => :repositories, :action => :show, :id => session[:repo_id] %>" class="btn btn-default navbar-btn">
+                  <span class="repository-label has-popover" tabindex="0" data-trigger="focus hover" data-placement="bottom" data-html='true' data-toggle='popover' data-title="<span class='icomoon icon-repository'>&#160;</span><%= CGI::escapeHTML(current_repo['repo_code']) %>" data-content="<%= CGI::escapeHTML(current_repo['name']) %>">
+                    <span class="icomoon icon-repository"></span><span class="current-repository-id"><% if current_repo %><%= current_repo['repo_code'] %><% end %></span>
+                    <% unless current_repo.publish %>
+                      <span class="badge badge-warning"><%= t("navbar.unpublished") %></span>
+                    <% end %>
+                  </span>
+                </a>
                 <div class="btn-group">
-                  <a href="<%= url_for :controller => :repositories, :action => :show, :id => session[:repo_id] %>" class="btn btn-default navbar-btn">
-                    <span class="repository-label has-popover" tabindex="0" data-trigger="focus hover" data-placement="bottom" data-html='true' data-toggle='popover' data-title="<span class='icomoon icon-repository'>&#160;</span><%= CGI::escapeHTML(current_repo['repo_code']) %>" data-content="<%= CGI::escapeHTML(current_repo['name']) %>">
-                      <span class="icomoon icon-repository"></span><span class="current-repository-id"><% if current_repo %><%= current_repo['repo_code'] %><% end %></span>
-                      <% unless current_repo.publish %>
-                        <span class="label label-warning"><%= I18n.t("navbar.unpublished") %></span>
-                      <% end %>
-                    </span>
-                  </a>
-                  <div class="btn-group">
-                    <a class="btn btn-default navbar-btn dropdown-toggle last" data-toggle="dropdown" href="#" title="<%= I18n.t("navbar.repository_settings") %>" aria-label="<%= I18n.t("navbar.repository_settings") %>"><span class="glyphicon glyphicon-cog"></span> <span class="caret"></span></a>
-                    <ul class="dropdown-menu pull-right">
-                      <% found_an_item = false %>
-                      <% if user_can?('manage_repository') %>
-                        <% found_an_item = true %>
-                        <li><%= link_to I18n.t("navbar.manage_groups"), :controller => :groups, :action => :index %></li>
-                        <li><%= link_to I18n.t("user._frontend.section.manage_access"), :controller => :users, :action => :manage_access %></li>
-                      <% end %>
-                      <% if user_can?('manage_assessment_attributes') %>
-                        <li><%= link_to I18n.t("navbar.manage_assessment_attributes"), :controller => :assessment_attributes, :action => :edit %></li>
-                      <% end %>
-                      <% if user_can?('view_repository') %>
-                        <% found_an_item = true %>
-                        <li><%= link_to I18n.t("navbar.manage_top_containers"), :controller => :top_containers, :action => :index %></li>
-                      <% end %>
-                      <% if found_an_item %>
-                        <li class="divider"></li>
-                      <% end %>
-                      <% if user_can?('transfer_repository') && @repositories.length > 1 %>
-                        <li><%= link_to I18n.t("repository._frontend.section.transfer"), :controller => :repositories, :action => :transfer, :id => session[:repo_id] %></li>
-                        <li class="divider"></li>
-                      <% end %>
-                      <% if user_can?('create_job') %>
-                         <li><%= link_to I18n.t("job._plural"), :controller => :jobs, :action => :index %></li>
-                         <li><%= link_to I18n.t("bulk_import.templates"), "https://confluence.si.edu/pages/viewpage.action?spaceKey=LAS&title=Import+Templates", :target => "_blank"  %></li>
-                        <li class="divider"></li>
-                      <% end %>
+                  <button class="btn btn-default navbar-btn dropdown-toggle" data-toggle="dropdown" title="<%= t("navbar.repository_settings") %>" aria-label="<%= t("navbar.repository_settings") %>"><span class="glyphicon glyphicon-cog mr-1"></span></button>
+                  <ul class="dropdown-menu dropdown-menu-right">
+                    <% found_an_item = false %>
+                    <% if user_can?('manage_repository') %>
+                      <% found_an_item = true %>
+                      <li><%= link_to t("navbar.manage_groups"), {:controller => :groups, :action => :index}, :class => "dropdown-item" %></li>
+                      <li><%= link_to t("user._frontend.section.manage_access"), {:controller => :users, :action => :manage_access}, :class => "dropdown-item" %></li>
+                    <% end %>
+                    <% if user_can?('manage_assessment_attributes') %>
+                      <li><%= link_to t("navbar.manage_assessment_attributes"), {:controller => :assessment_attributes, :action => :edit}, :class => "dropdown-item" %></li>
+                    <% end %>
+                    <% if user_can?('view_repository') %>
+                      <% found_an_item = true %>
+                      <li><%= link_to t("navbar.manage_top_containers"), {:controller => :top_containers, :action => :index}, :class => "dropdown-item" %></li>
+                    <% end %>
+                    <% if found_an_item %>
+                      <li class="dropdown-divider"></li>
+                    <% end %>
+                    <% if user_can?('transfer_repository') && @repositories.length > 1 %>
+                      <li><%= link_to t("repository._frontend.section.transfer"), {:controller => :repositories, :action => :transfer, :id => session[:repo_id]}, :class => "dropdown-item" %></li>
+                      <li class="dropdown-divider"></li>
+                    <% end %>
+                    <% if user_can?('create_job') %>
+                        <li><%= link_to t("job._plural"), {:controller => :jobs, :action => :index}, :class => "dropdown-item" %></li>
+                        <li><%= link_to t("bulk_import.templates"), "https://confluence.si.edu/pages/viewpage.action?spaceKey=LAS&title=Import+Templates", :target => "_blank", :class => "dropdown-item"  %></li>
+                      <li class="dropdown-divider"></li>
+                    <% end %>
 
-                      <li><%= link_to I18n.t("navbar.list_reports"), :controller => :jobs, :action => :new, :job_type => 'report_job' %></li>
-                      <% if user_can?('manage_custom_report_templates') && AppConfig[:enable_custom_reports] %>
-                        <li><%= link_to I18n.t("custom_report_template._plural"), :controller => :custom_report_templates, :action => :index %></li>
-                      <% end %>
+                    <li><%= link_to t("navbar.list_reports"), {:controller => :jobs, :action => :new, :job_type => 'report_job'}, :class => "dropdown-item" %></li>
+                    <% if user_can?('manage_custom_report_templates') && AppConfig[:enable_custom_reports] %>
+                      <li><%= link_to t("custom_report_template._plural"), {:controller => :custom_report_templates, :action => :index}, :class => "dropdown-item" %></li>
+                    <% end %>
 
-                      <% if Plugins.repository_menu_items.any? {|plugin| has_permission_for_controller?(session, plugin)} %>
-                        <li class="dropdown-submenu pull-left">
-                          <a href="javascript:void(0);"><%= I18n.t("navbar.plugins") %></a>
+                    <% if Plugins.repository_menu_items.any? {|plugin| has_permission_for_controller?(session, plugin)} %>
+                      <li>
+                        <div class="btn-group dropdown-item dropdown-submenu dropleft px-0">
+                          <button type="button" class="btn dropdown-toggle py-0 border-0 rounded-0 text-left" data-toggle="dropdown"><%= t("navbar.plugins") %></button>
                           <ul class="dropdown-menu">
                             <% Plugins.repository_menu_items.each do |plugin| %>
                               <% if has_permission_for_controller?(session, plugin) %>
-                                <li><%= link_to I18n.t("plugins.#{plugin}.label"), :controller => plugin.intern, :action => :index %></li>
+                                <li><%= link_to t("plugins.#{plugin}.label"), {:controller => plugin.intern, :action => :index}, :class => "dropdown-item px-4 py-1" %></li>
                               <% end %>
                             <% end %>
                           </ul>
-                        </li>
-                      <% end %>
-                    </ul>
-                  </div>
+                        </div>
+                      </li>
+                    <% end %>
+                  </ul>
                 </div>
+              </div>
               </li>
               <% if ArchivesSpaceHelp.enabled? %>
                 <li><%= link_to_help %></li>
@@ -199,9 +190,12 @@
             </ul>
           </li>
         </ul>
+        <section class="w-100 bg-grayLighter">
+          <div class="advanced-search-container" <% if params["advanced"].blank? or params["advanced"]  === 'false' %>style="display: none"<% end %>>
+            <%= render_aspace_partial :partial => "shared/advanced_search" %>
+          </div>
+        </section>
       <% end %>
     </div>
-  </div>
-</nav>
-
+  </nav>
 </div>

--- a/frontend/views/shared/_header_user.html.erb
+++ b/frontend/views/shared/_header_user.html.erb
@@ -82,7 +82,9 @@
         <li class="dropdown-divider"></li>
         <% if user_can?('become_user') %>
           <li><%= link_to t("navbar.become-user"), {:controller => "session", :action => "select_user"}, :class => "dropdown-item" %></li>
+          <%# SI Override - Only allow those with 'become_user' permissions to update user account %>
           <li><%= link_to t('user._frontend.action.update_self'), {:controller => :users, :action => :edit_self}, :class => "dropdown-item" %></li>
+          <%# End SI Override %>
         <% end %>
         <li><%= link_to t("navbar.logout"), {:controller => "session",:action => "logout"}, :class => "dropdown-item" %></li>
       </ul>

--- a/frontend/views/shared/_header_user.html.erb
+++ b/frontend/views/shared/_header_user.html.erb
@@ -3,94 +3,89 @@
 <% if session[:user] %>
   <% if @repositories.length > 0 %>
     <li class="dropdown select-a-repository">
-      <a href="javascript:void(0);" class="dropdown-toggle" data-toggle="dropdown"><%= I18n.t("repository._frontend.action.select") %> <b class="caret"></b></a>
-      <ul class="dropdown-menu" style="padding: 15px;">
+      <button type="button" class="btn d-flex align-items-center gap-x-1 dropdown-toggle" style="padding: .875rem;" data-toggle="dropdown"><%= t("repository._frontend.action.select") %></button>
+      <ul class="dropdown-menu dropdown-menu-right" style="padding: 15px;">
         <li>
           <%= form_tag({:controller => :repositories, :action => :select}) do |f| %>
             <fieldset>
-              <label for="id" class="sr-only"><%= I18n.t('repository._frontend.action.select') %></label>
+              <label for="id" class="sr-only"><%= t('repository._frontend.action.select') %></label>
               <%= select_tag "id", options_for_select(@repositories.map {|repo| [repo.repo_code, repo.id]}, session[:repo_id]), :class=>"form-control" %>
             </fieldset>
             <br />
-            <button class="btn btn-primary pull-left"><%= I18n.t("repository._frontend.action.select") %></button>
+            <button class="btn btn-primary float-xs-left"><%= t("repository._frontend.action.select") %></button>
           <% end %>
         </li>
       </ul>
     </li>
   <% end %>
   <li class="dropdown system-menu">
-    <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= I18n.t("navbar.global_admin") %> <b class="caret"></b></a>
-    <ul class="dropdown-menu">
+    <button type="button" class="btn d-flex align-items-center gap-x-1 dropdown-toggle" style="padding: .875rem;" data-toggle="dropdown"><%= t("navbar.global_admin") %></button>
+    <ul class="dropdown-menu dropdown-menu-right">
       <% if user_can?('update_enumeration_record') %>
-        <li><%= link_to I18n.t("navbar.manage_enumerations"), :controller => :enumerations, :action => :index %></li>
+        <li><%= link_to t("navbar.manage_enumerations"), {:controller => :enumerations, :action => :index}, :class => "dropdown-item" %></li>
       <% end %>
       <% if user_can?('update_container_profile_record') %>
-        <li><%= link_to I18n.t("navbar.manage_container_profiles"), :controller => :container_profiles, :action => :index %></li>
+        <li><%= link_to t("navbar.manage_container_profiles"), {:controller => :container_profiles, :action => :index}, :class => "dropdown-item" %></li>
       <% end %>
       <% if user_can?('manage_location_profile_record')%>
-        <li><%= link_to I18n.t("navbar.manage_location_profiles"), :controller => :location_profiles, :action => :index %></li>
+        <li><%= link_to t("navbar.manage_location_profiles"), {:controller => :location_profiles, :action => :index}, :class => "dropdown-item" %></li>
       <% end %>
 
       <% if user_can?('update_enumeration_record') || user_can?('update_container_profile_record') || user_can?('manage_location_profile_record') %>
-        <li class="divider"></li>
+        <li class="dropdown-divider"></li>
       <% end %>
 
       <% if user_can?('create_repository') %>
-        <li><%= link_to I18n.t("navbar.repositories_manage"), {:controller => :repositories, :action => :index} %></li>
+        <li><%= link_to t("navbar.repositories_manage"), {:controller => :repositories, :action => :index}, :class => "dropdown-item" %></li>
       <% end %>
       <% if user_can?('create_repository') %>
-        <li><%= link_to I18n.t("navbar.oai_config"), {:controller => :oai_config, :action => :edit} %></li>
+        <li><%= link_to t("navbar.oai_config"), {:controller => :oai_config, :action => :edit}, :class => "dropdown-item" %></li>
       <% end %>
       <% if user_can?('manage_users') %>
-        <li><%= link_to I18n.t("navbar.manage_users"), :controller => :users, :action => :create %></li>
+        <li><%= link_to t("navbar.manage_users"), {:controller => :users, :action => :create}, :class => "dropdown-item" %></li>
       <% end %>
       <% if user_can?('create_repository') || user_can?('manage_users') %>
-        <li><%= link_to I18n.t("navbar.system_info"), :controller => :system_info, :action => :show %></li>
-        <li class="divider"></li>
+        <li><%= link_to t("navbar.system_info"), {:controller => :system_info, :action => :show}, :class => "dropdown-item" %></li>
+        <li class="dropdown-divider"></li>
       <% end %>
 
       <% if ArchivesSpaceHelp.enabled? %>
-        <li><%= link_to_help :label => I18n.t("help.help_center") %></li>
+        <li><%= link_to_help :label => t("help.help_center"), :class => 'dropdown-item', :style => 'padding: 0.25rem 1.5rem' %></li>
       <% end %>
     </ul>
   </li>
 
   <% if Plugins.system_menu_items.any? {|plugin| has_permission_for_controller?(session, plugin)} %>
     <li class="dropdown plugin-container">
-      <a href="#" class="dropdown-toggle" data-toggle="dropdown"><%= I18n.t("navbar.plugins") %> <b class="caret"></b></a>
-      <ul class="dropdown-menu">
+      <button type="button" class="btn d-flex align-items-center gap-x-1 dropdown-toggle" style="padding: .875rem;" data-toggle="dropdown"><%= t("navbar.plugins") %></button>
+      <ul class="dropdown-menu dropdown-menu-right">
         <% Plugins.system_menu_items.each do |plugin| %>
           <% if has_permission_for_controller?(session, plugin) %>
-            <li><%= link_to I18n.t("plugins.#{plugin}.label"), :controller => plugin.intern, :action => :index %></li>
+            <li><%= link_to t("plugins.#{plugin}.label"), {:controller => plugin.intern, :action => :index}, :class => "dropdown-item" %></li>
           <% end %>
         <% end %>
       </ul>
     </li>
   <% end %>
 
-  <li class="user-container">
-    <div class="btn-group">
-
+  <li class="user-container d-flex align-items-center">
+    <div class="btn-group align-items-center">
       <% link_content = "<span class='glyphicon glyphicon-user'></span>&nbsp;<span class='user-label'>#{session[:user]}</span>" %>
-      <%= link_to(link_content.html_safe, {:controller => :users, :action => :edit_self}, {:class => 'btn btn-default navbar-btn'}) %>
-
-      <div class="btn-group">
-        <a class="btn btn-default navbar-btn dropdown-toggle last" id="user-menu-dropdown" data-toggle="dropdown" href="#" title="<%= I18n.t("navbar.global_settings") %>" aria-label="<%= I18n.t("navbar.global_settings") %>"><span class="caret"></span></a>
-        <ul class="dropdown-menu pull-right">
-
-          <li><%= link_to I18n.t("navbar.global_preferences") + " (#{username})", :controller => :preferences, :action => :edit, :id => 0, :global => true %></li>
-          <li><%= link_to I18n.t("navbar.user_repo_preferences") + " (#{username})", :controller => :preferences, :action => :edit, :id => 0 %></li>
-          <% if user_can?('administer_system') || user_can?('manage_repository') %>
-            <li><%= link_to I18n.t("navbar.repo_preferences"), :controller => :preferences, :action => :edit, :id => 0, :repo => true %></li>
-          <% end %>
-          <li class="divider"></li>
-          <% if user_can?('become_user') %>
-            <li><%= link_to I18n.t("navbar.become-user"), :controller => "session", :action => "select_user" %></li>
-            <li><%= link_to(I18n.t('user._frontend.action.update_self'), {:controller => :users, :action => :edit_self}) %></li>
-          <% end %>
-          <li><%= link_to I18n.t("navbar.logout"), :controller => "session",:action => "logout"%></li>
-        </ul>
-      </div>
+      <%= link_to(link_content.html_safe, {:controller => :users, :action => :edit_self}, {:class => 'btn btn-default'}) %>
+      <button type="button" class="btn btn-default dropdown-toggle" id="user-menu-dropdown" data-toggle="dropdown" title="<%= t("navbar.global_settings") %>" aria-label="<%= t("navbar.global_settings") %>"></button>
+      <ul class="dropdown-menu dropdown-menu-right">
+        <li><%= link_to t("navbar.global_preferences") + " (#{username})", {:controller => :preferences, :action => :edit, :id => 0, :global => true}, :class => "dropdown-item" %></li>
+        <li><%= link_to t("navbar.user_repo_preferences") + " (#{username})", {:controller => :preferences, :action => :edit, :id => 0}, :class => "dropdown-item" %></li>
+        <% if user_can?('administer_system') || user_can?('manage_repository') %>
+          <li><%= link_to t("navbar.repo_preferences"), {:controller => :preferences, :action => :edit, :id => 0, :repo => true}, :class => "dropdown-item" %></li>
+        <% end %>
+        <li class="dropdown-divider"></li>
+        <% if user_can?('become_user') %>
+          <li><%= link_to t("navbar.become-user"), {:controller => "session", :action => "select_user"}, :class => "dropdown-item" %></li>
+          <li><%= link_to t('user._frontend.action.update_self'), {:controller => :users, :action => :edit_self}, :class => "dropdown-item" %></li>
+        <% end %>
+        <li><%= link_to t("navbar.logout"), {:controller => "session",:action => "logout"}, :class => "dropdown-item" %></li>
+      </ul>
     </div>
   </li>
 <% end %>


### PR DESCRIPTION
Closes #3 , #4 , and #5 .  Updates to make plugin compatible with aspace v4.x.  Also adds standard repo templates and ci setup.

Note: The Diff check in CI will fail under v3.3.1, which of course makes sense.  This is not a blocking failure.