### PR TITLE
[BUG] Fix "Add Duplicate" duplications of note persistent identifiers

### DIFF
--- a/.github/workflows/frontend_plugin_test.yml
+++ b/.github/workflows/frontend_plugin_test.yml
@@ -1,0 +1,63 @@
+name: Frontend Plugin Testing
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+
+jobs:
+  frontend_plugins:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[ci skip]') }}
+    env:
+      DB_PORT: '3307'
+      SOLR_ENABLED: true
+    continue-on-error: true
+    strategy:
+      matrix:
+        archivesspace_version: [v4.1.0, v4.1.1]
+
+    services:
+      db:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: archivesspace
+          MYSQL_USER: as
+          MYSQL_PASSWORD: as123
+        ports:
+          - 3307:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+      solr:
+        image: solr:9.4.1
+        env:
+          SOLR_MODULES: analysis-extras
+        ports:
+          - 8984:8983
+
+    steps:
+    - name: Setup ArchivesSpace ${{ matrix.archivesspace_version }}
+      uses: Smithsonian/caas-aspace-services/.github/actions/setup_archivesspace@main
+      with:
+        archivesspace-version: ${{ matrix.archivesspace_version }}
+        db-port: ${{ env.DB_PORT }}
+        plugin: ${{ github.event.repository.name }}
+        solr-enabled: ${{ env.SOLR_ENABLED }}
+
+    - name: Bootstrap ArchivesSpace
+      uses: Smithsonian/caas-aspace-services/.github/actions/bootstrap@main
+      with:
+        backend: 'true'
+        frontend: 'true'
+        indexer: 'true'
+
+    - name: Run Frontend plugin tests
+      run: |
+        ./build/run frontend:test -Dpattern="../../plugins/${{ github.event.repository.name }}/frontend/spec/*"
+
+    - uses: actions/upload-artifact@v4
+      if: failure()
+      with:
+        name: failed_frontend_spec_${{ github.event.repository.name }}_${{ matrix.archivesspace_version }}
+        path: 'ci_logs'

--- a/frontend/controllers/archival_objects_controller_ext.rb
+++ b/frontend/controllers/archival_objects_controller_ext.rb
@@ -1,0 +1,41 @@
+ArchivalObjectsController.class_eval do
+
+  def new
+    if params[:duplicate_from_archival_object]
+      new_find_opts = find_opts
+      new_find_opts["resolve[]"].push("top_container::container_locations")
+
+      archival_object_id = params[:duplicate_from_archival_object][:uri].split('/').pop
+
+      @archival_object = JSONModel(:archival_object).find(archival_object_id, new_find_opts)
+      @archival_object.ref_id = nil
+      @archival_object.instances = []
+      @archival_object.position = params[:position]
+      @archival_object.notes.each do |note|
+        if note.is_a?(Hash)
+          note.delete('persistent_id')
+        end
+      end
+
+      flash[:success] = t("archival_object._frontend.messages.duplicated", archival_object_display_string: clean_mixed_content(@archival_object.display_string))
+    else
+      @archival_object = ArchivalObject.new._always_valid!
+      @archival_object.parent = {'ref' => ArchivalObject.uri_for(params[:archival_object_id])} if params.has_key?(:archival_object_id)
+      @archival_object.resource = {'ref' => Resource.uri_for(params[:resource_id])} if params.has_key?(:resource_id)
+      @archival_object.position = params[:position]
+      if defaults = user_defaults('archival_object')
+        @archival_object.update(defaults.values)
+      end
+
+      if params[:accession_id]
+        acc = Accession.find(params[:accession_id], find_opts)
+        @archival_object.populate_from_accession(acc)
+
+        flash.now[:info] = t("archival_object._frontend.messages.spawned", accession_display_string: clean_mixed_content(acc.title))
+        flash[:spawned_from_accession] = acc.id
+      end
+    end
+
+    return render_aspace_partial :partial => "archival_objects/new_inline" if inline?
+  end
+end

--- a/frontend/spec/archival_objects_controller_ext_spec.rb
+++ b/frontend/spec/archival_objects_controller_ext_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'rails_helper'
+
+describe ArchivalObjectsController, type: :controller do
+  render_views
+
+  before(:each) do
+    set_repo($repo)
+    session = User.login('admin', 'admin')
+    User.establish_session(controller, session, 'admin')
+    controller.session[:repo_id] = JSONModel.repository
+  end
+
+  describe "New Archival Object" do
+    let (:resource) { create(:json_resource) }
+    let (:archival_object_with_note) { create(:json_archival_object,
+                                               :notes => [ build(:json_note_singlepart) ],
+                                               :resource => {'ref' => resource.uri}) }
+
+    it "does not duplicate persistent id when duplicating an archival object note" do
+      get :new, params: { resource_id: resource.id,
+                          duplicate_from_archival_object: { uri: archival_object_with_note.uri } }
+
+      expect(response.status).to eq 200
+      result = Capybara.string(response.body)
+
+      result.find(:css, "#archival_object_notes__0__persistent_id_") do |new_persistent_id|
+        expect(new_persistent_id.value).to eq("")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #13

## Description
<!--- Describe your changes.  Why is this required?  What problem does it solve?  What functionality does it extend? -->
Temporarily patches the archival object controller to avoid duplicating note persistent ids.  It's assumed these changes can be removed when/if this is merged to core: https://github.com/archivesspace/archivesspace/pull/3676

## Related GitHub Issue
<!--- Please link to GitHub Issue here: -->
#13 

## Testing
<!--- Please describe, in detail, how you tested your changes. -->
Single test added and GH Actions extended to run this frontend test.  Also locally ran the relevant core frontend controller tests and confirmed no core functionality was impacted.

## Screenshot(s):
<!--- Optional screenshots of changes if relevant and helpful to reviewers -->

## Checklist

- [x] ✔️ Have you assigned at least one reviewer?
- [x] 🔗 Have you referenced any issues this PR will close?
- [x] ⬇️ Have you merged the latest upstream changes into your branch? 
- [x] 🧪 Have you added tests to cover these changes?  If not, why:
- [x] 🤖 Have automated checks (if any) passed?  If not, please explain for the reviewer:
- [x] 📘 Have you updated/added any relevant readmes/comments in the codebase?
- [x] 📚 Have you updated/added any external documentation (e.g. Confluence)?
